### PR TITLE
feat: Careerセクションを日付降順ソート + Load more表示に対応

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import About from '../components/About';
 import Works from '../components/Works';
 import { data, careerData } from '../../data/index';
 import Biography from '../components/Biography';
-import Career from '../components/Career';
+import CareerList from '../components/CareerList';
 import React from 'react';
 
 export const metadata: Metadata = {
@@ -56,15 +56,7 @@ export default function Page() {
       <section className="py-16">
         <SectionHeader id="career">Career</SectionHeader>
         <div className="mx-auto max-w-2xl">
-          {careerData.map(({ company, term, contents, details }) => (
-            <Career
-              key={company}
-              company={company}
-              term={term}
-              contents={contents}
-              details={details}
-            />
-          ))}
+          <CareerList items={careerData} initialVisibleCount={5} />
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
       <section className="py-16">
         <SectionHeader id="career">Career</SectionHeader>
         <div className="mx-auto max-w-2xl">
-          <CareerList items={careerData} initialVisibleCount={5} />
+          <CareerList items={careerData} />
         </div>
       </section>
 

--- a/src/components/CareerList.tsx
+++ b/src/components/CareerList.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import Career from './Career';
+
+type CareerItem = {
+  company: string;
+  term: string;
+  contents: string;
+  details: string;
+};
+
+type Props = {
+  items: CareerItem[];
+  initialVisibleCount?: number;
+};
+
+const parseStartDate = (term: string): number => {
+  const match = term.match(/(\d{4})\/(\d{1,2})/);
+  if (!match) return 0;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  return year * 100 + month;
+};
+
+const CareerList = ({ items, initialVisibleCount = 5 }: Props) => {
+  const sortedItems = useMemo(
+    () => [...items].sort((a, b) => parseStartDate(b.term) - parseStartDate(a.term)),
+    [items]
+  );
+
+  const [expanded, setExpanded] = useState(false);
+  const hasMore = sortedItems.length > initialVisibleCount;
+  const visibleItems = expanded ? sortedItems : sortedItems.slice(0, initialVisibleCount);
+
+  return (
+    <>
+      {visibleItems.map(({ company, term, contents, details }) => (
+        <Career key={company} company={company} term={term} contents={contents} details={details} />
+      ))}
+      {hasMore && (
+        <div className="mt-4 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            className="rounded-full border border-border-accent bg-primary-500/10 px-6 py-2.5 text-sm font-medium text-primary-400 transition-all hover:bg-primary-500/20"
+          >
+            {expanded ? 'Show less' : 'Load more...'}
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CareerList;

--- a/src/components/CareerList.tsx
+++ b/src/components/CareerList.tsx
@@ -15,15 +15,19 @@ type Props = {
   initialVisibleCount?: number;
 };
 
+const DEFAULT_INITIAL_VISIBLE_COUNT = 5;
+const YEAR_MONTH_ENCODING_BASE = 100;
+const INVALID_DATE_SORT_KEY = 0;
+
 const parseStartDate = (term: string): number => {
   const match = term.match(/(\d{4})\/(\d{1,2})/);
-  if (!match) return 0;
+  if (!match) return INVALID_DATE_SORT_KEY;
   const year = Number(match[1]);
   const month = Number(match[2]);
-  return year * 100 + month;
+  return year * YEAR_MONTH_ENCODING_BASE + month;
 };
 
-const CareerList = ({ items, initialVisibleCount = 5 }: Props) => {
+const CareerList = ({ items, initialVisibleCount = DEFAULT_INITIAL_VISIBLE_COUNT }: Props) => {
   const sortedItems = useMemo(
     () => [...items].sort((a, b) => parseStartDate(b.term) - parseStartDate(a.term)),
     [items]


### PR DESCRIPTION
## Summary
- Careerセクションを開始日(YYYY/MM)基準で**降順ソート**し、最新の経歴を先頭に表示
- 初期表示を**5件**に制限し、超過分は「Load more...」ボタンで展開、「Show less」で折りたたみ可能に
- `CareerList` をクライアントコンポーネントとして新規追加し、`page.tsx` から差し替え

## 変更ファイル
- `src/components/CareerList.tsx` (新規): ソート + 表示件数トグルを担うクライアントコンポーネント
- `src/app/page.tsx`: Career セクションを `CareerList` 経由でレンダリング

## Test plan
- [ ] `yarn dev` で起動し、Career セクションが最新→古い順で並んでいることを確認
- [ ] 初期状態で5件のみ表示されていることを確認
- [ ] 「Load more...」クリックで残りの経歴が表示されることを確認
- [ ] 「Show less」クリックで5件表示に戻ることを確認
- [ ] `yarn lint` がパス（確認済み）


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkcVBUGuBNNUu1SrrJKxfz)_