### PR TITLE
feat: 青×黒ベースのスタイリッシュな演出を追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,15 +2,17 @@
 
 @theme {
   --font-sans: 'Inter', 'Noto Sans JP', system-ui, -apple-system, sans-serif;
-  --color-primary-400: #818cf8;
-  --color-primary-500: #6366f1;
-  --color-primary-600: #4f46e5;
-  --color-surface: #0f1117;
-  --color-surface-card: rgba(255, 255, 255, 0.04);
-  --color-surface-card-hover: rgba(255, 255, 255, 0.08);
-  --color-border-subtle: rgba(255, 255, 255, 0.08);
-  --color-border-accent: rgba(99, 102, 241, 0.3);
-  --color-text-primary: #f1f5f9;
+  --color-primary-400: #60a5fa;
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-accent-cyan: #38bdf8;
+  --color-accent-deep: #1e40af;
+  --color-surface: #05080f;
+  --color-surface-card: rgba(255, 255, 255, 0.035);
+  --color-surface-card-hover: rgba(96, 165, 250, 0.08);
+  --color-border-subtle: rgba(255, 255, 255, 0.07);
+  --color-border-accent: rgba(59, 130, 246, 0.35);
+  --color-text-primary: #e6edf7;
   --color-text-secondary: #94a3b8;
   --color-text-muted: #64748b;
 }
@@ -22,31 +24,78 @@ html {
 body {
   background-color: var(--color-surface);
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
-/* Gradient text utility */
+/* Gradient text — blue→cyan→deep-blue shimmer */
 .gradient-text {
-  background: linear-gradient(135deg, #818cf8 0%, #c084fc 50%, #f472b6 100%);
+  background: linear-gradient(135deg, #7dd3fc 0%, #38bdf8 45%, #3b82f6 100%);
+  background-size: 200% 200%;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  animation: gradientShift 9s ease-in-out infinite;
 }
 
-/* Glassmorphism card */
+@keyframes gradientShift {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+/* Glassmorphism card + mouse-tracking spotlight overlay */
 .glass-card {
+  position: relative;
   background: var(--color-surface-card);
   backdrop-filter: blur(12px);
   border: 1px solid var(--color-border-subtle);
-  transition: all 0.3s ease;
+  transition:
+    background 0.3s ease,
+    border-color 0.3s ease,
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.glass-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    480px circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
+    rgba(96, 165, 250, 0.22),
+    rgba(56, 189, 248, 0.1) 25%,
+    transparent 55%
+  );
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.glass-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.glass-card:hover::before {
+  opacity: 1;
 }
 
 .glass-card:hover {
   background: var(--color-surface-card-hover);
   border-color: var(--color-border-accent);
-  transform: translateY(-2px);
+  transform: translateY(-3px);
+  box-shadow: 0 14px 40px -10px rgba(59, 130, 246, 0.3);
 }
 
-/* Section fade-in */
+/* Section fade-in (legacy utility) */
 @keyframes fadeInUp {
   from {
     opacity: 0;
@@ -59,10 +108,25 @@ body {
 }
 
 .animate-fade-in-up {
-  animation: fadeInUp 0.6s ease-out forwards;
+  animation: fadeInUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
-/* Glow effect for hero */
+/* Scroll reveal */
+.reveal {
+  opacity: 0;
+  transform: translateY(28px);
+  transition:
+    opacity 0.9s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: opacity, transform;
+}
+
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Profile image glow ring */
 .glow {
   position: relative;
 }
@@ -70,17 +134,30 @@ body {
 .glow::before {
   content: '';
   position: absolute;
-  inset: -1px;
+  inset: -2px;
   border-radius: inherit;
-  background: linear-gradient(135deg, #818cf8, #c084fc, #f472b6);
-  opacity: 0;
+  background: linear-gradient(135deg, #60a5fa, #38bdf8, #1e40af);
+  opacity: 0.55;
   transition: opacity 0.3s ease;
   z-index: -1;
-  filter: blur(8px);
+  filter: blur(10px);
+  animation: pulseGlow 5s ease-in-out infinite;
 }
 
 .glow:hover::before {
-  opacity: 0.6;
+  opacity: 0.95;
+}
+
+@keyframes pulseGlow {
+  0%,
+  100% {
+    opacity: 0.4;
+    filter: blur(10px);
+  }
+  50% {
+    opacity: 0.75;
+    filter: blur(14px);
+  }
 }
 
 /* Timeline connector */
@@ -97,8 +174,9 @@ body {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #818cf8, #c084fc);
-  box-shadow: 0 0 8px rgba(129, 140, 248, 0.4);
+  background: linear-gradient(135deg, #60a5fa, #38bdf8);
+  box-shadow: 0 0 12px rgba(96, 165, 250, 0.7);
+  z-index: 1;
 }
 
 .timeline-item::after {
@@ -108,31 +186,245 @@ body {
   top: 1.6rem;
   width: 2px;
   height: calc(100% - 0.6rem);
-  background: linear-gradient(to bottom, rgba(129, 140, 248, 0.3), transparent);
+  background: linear-gradient(to bottom, rgba(96, 165, 250, 0.45), transparent);
 }
 
 .timeline-item:last-child::after {
   display: none;
 }
 
-/* Subtle grid pattern background */
+/* Subtle grid pattern */
 .bg-grid-pattern {
   background-image: radial-gradient(
     circle at 1px 1px,
-    rgba(255, 255, 255, 0.03) 1px,
+    rgba(125, 211, 252, 0.05) 1px,
     transparent 0
   );
   background-size: 40px 40px;
 }
 
-/* Tag/badge styles */
+/* Tech badge */
 .tech-badge {
   display: inline-block;
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 500;
-  background: rgba(99, 102, 241, 0.15);
-  color: #a5b4fc;
-  border: 1px solid rgba(99, 102, 241, 0.2);
+  background: rgba(59, 130, 246, 0.14);
+  color: #93c5fd;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  transition:
+    background 0.3s ease,
+    border-color 0.3s ease,
+    color 0.3s ease;
+}
+
+.tech-badge:hover {
+  background: rgba(59, 130, 246, 0.24);
+  border-color: rgba(96, 165, 250, 0.5);
+  color: #bfdbfe;
+}
+
+/* Aurora ambient background — blue/cyan blobs over near-black */
+.aurora {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.aurora span {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.42;
+  will-change: transform;
+}
+
+.aurora span:nth-child(1) {
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle, #3b82f6 0%, transparent 70%);
+  top: -140px;
+  left: -120px;
+  animation: floatA 22s ease-in-out infinite;
+}
+
+.aurora span:nth-child(2) {
+  width: 620px;
+  height: 620px;
+  background: radial-gradient(circle, #38bdf8 0%, transparent 70%);
+  top: 22%;
+  right: -180px;
+  animation: floatB 28s ease-in-out infinite;
+  opacity: 0.35;
+}
+
+.aurora span:nth-child(3) {
+  width: 440px;
+  height: 440px;
+  background: radial-gradient(circle, #1e40af 0%, transparent 70%);
+  bottom: -120px;
+  left: 28%;
+  animation: floatC 26s ease-in-out infinite;
+  opacity: 0.55;
+}
+
+@keyframes floatA {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  33% {
+    transform: translate(120px, 90px) scale(1.1);
+  }
+  66% {
+    transform: translate(-40px, 140px) scale(0.9);
+  }
+}
+
+@keyframes floatB {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  33% {
+    transform: translate(-100px, 70px) scale(0.95);
+  }
+  66% {
+    transform: translate(70px, -90px) scale(1.08);
+  }
+}
+
+@keyframes floatC {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  33% {
+    transform: translate(80px, -110px) scale(1.1);
+  }
+  66% {
+    transform: translate(-90px, -60px) scale(0.95);
+  }
+}
+
+/* Hero ambient glow */
+.hero-glow {
+  position: absolute;
+  width: 680px;
+  height: 680px;
+  max-width: 90vw;
+  max-height: 90vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.38) 0%, transparent 65%);
+  filter: blur(60px);
+  pointer-events: none;
+  animation: pulseGlow 7s ease-in-out infinite;
+}
+
+/* Scroll indicator chevron */
+@keyframes scrollBounce {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.55;
+  }
+  50% {
+    transform: translateY(8px);
+    opacity: 1;
+  }
+}
+
+.scroll-indicator {
+  animation: scrollBounce 2.2s ease-in-out infinite;
+}
+
+/* Nav underline */
+.nav-link {
+  position: relative;
+}
+
+.nav-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  height: 2px;
+  width: 100%;
+  background: linear-gradient(90deg, #60a5fa, #38bdf8);
+  transform: scaleX(0);
+  transform-origin: right center;
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+  border-radius: 2px;
+}
+
+.nav-link:hover::after {
+  transform: scaleX(1);
+  transform-origin: left center;
+}
+
+/* Sequential hero entry */
+.hero-enter > * {
+  opacity: 0;
+  animation: fadeInUp 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.hero-enter > *:nth-child(1) {
+  animation-delay: 0.05s;
+}
+.hero-enter > *:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.hero-enter > *:nth-child(3) {
+  animation-delay: 0.32s;
+}
+.hero-enter > *:nth-child(4) {
+  animation-delay: 0.5s;
+}
+.hero-enter > *:nth-child(5) {
+  animation-delay: 0.7s;
+}
+
+/* CTA glow */
+.btn-glow {
+  position: relative;
+  isolation: isolate;
+}
+
+.btn-glow::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #60a5fa, #38bdf8, #2563eb);
+  opacity: 0;
+  filter: blur(14px);
+  transition: opacity 0.3s ease;
+  z-index: -1;
+}
+
+.btn-glow:hover::before {
+  opacity: 0.8;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .gradient-text,
+  .aurora span,
+  .hero-glow,
+  .glow::before,
+  .scroll-indicator,
+  .hero-enter > * {
+    animation: none !important;
+  }
+  .hero-enter > * {
+    opacity: 1 !important;
+  }
+  .reveal {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Header from '../components/layouts/Header';
 import Footer from '../components/layouts/Footer';
+import AmbientBackground from '../components/effects/AmbientBackground';
+import CursorSpotlight from '../components/effects/CursorSpotlight';
 import './globals.css';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -16,9 +18,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="bg-grid-pattern font-sans text-text-primary antialiased">
-        <Header />
-        <main>{children}</main>
-        <Footer />
+        <AmbientBackground />
+        <CursorSpotlight />
+        <div className="relative z-10 flex min-h-screen flex-col">
+          <Header />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { data, careerData } from '../../data/index';
 import Biography from '../components/Biography';
 import CareerList from '../components/CareerList';
 import ScrollReveal from '../components/effects/ScrollReveal';
+import SectionArrow from '../components/SectionArrow';
 import React from 'react';
 
 export const metadata: Metadata = {
@@ -50,30 +51,20 @@ export default function Page() {
               View Works
             </a>
           </div>
-          <a
-            href="#about"
-            aria-label="Scroll down"
-            className="scroll-indicator mt-10 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle text-primary-400 no-underline transition-colors hover:border-border-accent hover:text-primary-400"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </a>
+          <SectionArrow href="#about" label="Scroll to About" />
         </div>
       </section>
 
-      {/* About & Biography */}
+      {/* About */}
       <ScrollReveal>
         <About />
+        <SectionArrow href="#biography" label="Scroll to Biography" />
       </ScrollReveal>
+
+      {/* Biography */}
       <ScrollReveal delay={80}>
         <Biography />
+        <SectionArrow href="#career" label="Scroll to Career" />
       </ScrollReveal>
 
       {/* Career Section */}
@@ -83,6 +74,7 @@ export default function Page() {
           <div className="mx-auto max-w-2xl">
             <CareerList items={careerData} />
           </div>
+          <SectionArrow href="#works" label="Scroll to Works" />
         </section>
       </ScrollReveal>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ export default function Page() {
   return (
     <div className="mx-auto max-w-5xl px-6">
       {/* Hero Section */}
-      <section className="relative flex min-h-[70vh] flex-col items-center justify-center py-20 text-center">
+      <section className="relative flex min-h-[78vh] flex-col items-center justify-center pb-8 pt-16 text-center">
         <div className="hero-glow absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
 
         <div className="hero-enter relative flex flex-col items-center">
@@ -53,7 +53,7 @@ export default function Page() {
           <a
             href="#about"
             aria-label="Scroll down"
-            className="scroll-indicator mt-16 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle text-primary-400 no-underline transition-colors hover:border-border-accent hover:text-primary-400"
+            className="scroll-indicator mt-10 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle text-primary-400 no-underline transition-colors hover:border-border-accent hover:text-primary-400"
           >
             <svg
               className="h-4 w-4"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import Works from '../components/Works';
 import { data, careerData } from '../../data/index';
 import Biography from '../components/Biography';
 import CareerList from '../components/CareerList';
+import ScrollReveal from '../components/effects/ScrollReveal';
 import React from 'react';
 
 export const metadata: Metadata = {
@@ -14,7 +15,7 @@ export const metadata: Metadata = {
 const SectionHeader = ({ children, id }: { children: React.ReactNode; id?: string }) => (
   <div id={id} className="mb-10 scroll-mt-20 text-center">
     <h2 className="gradient-text inline-block text-3xl font-bold">{children}</h2>
-    <div className="mx-auto mt-3 h-0.5 w-12 rounded-full bg-gradient-to-r from-primary-400 to-purple-400" />
+    <div className="mx-auto mt-3 h-0.5 w-12 rounded-full bg-gradient-to-r from-primary-400 to-accent-cyan" />
   </div>
 );
 
@@ -22,53 +23,80 @@ export default function Page() {
   return (
     <div className="mx-auto max-w-5xl px-6">
       {/* Hero Section */}
-      <section className="flex min-h-[60vh] flex-col items-center justify-center py-20 text-center">
-        <p className="mb-4 text-sm font-medium uppercase tracking-widest text-primary-400">
-          Frontend Engineer
-        </p>
-        <h1 className="mb-6 text-4xl font-extrabold leading-tight text-text-primary sm:text-5xl md:text-6xl">
-          Hi, I&apos;m <span className="gradient-text">Shohei Kikuchi</span>
-        </h1>
-        <p className="mx-auto max-w-xl text-lg leading-relaxed text-text-secondary">
-          TypeScript / React / Next.js を中心としたモダンなWeb開発に取り組んでいます。
-        </p>
-        <div className="mt-10 flex gap-4">
+      <section className="relative flex min-h-[70vh] flex-col items-center justify-center py-20 text-center">
+        <div className="hero-glow absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
+
+        <div className="hero-enter relative flex flex-col items-center">
+          <p className="mb-4 text-sm font-medium uppercase tracking-[0.3em] text-primary-400">
+            Frontend Engineer
+          </p>
+          <h1 className="mb-6 text-4xl font-extrabold leading-tight text-text-primary sm:text-5xl md:text-6xl">
+            Hi, I&apos;m <span className="gradient-text">Shohei Kikuchi</span>
+          </h1>
+          <p className="mx-auto max-w-xl text-lg leading-relaxed text-text-secondary">
+            TypeScript / React / Next.js を中心としたモダンなWeb開発に取り組んでいます。
+          </p>
+          <div className="mt-10 flex gap-4">
+            <a
+              href="#about"
+              className="btn-glow rounded-full bg-primary-500 px-6 py-2.5 text-sm font-medium text-white no-underline transition-all hover:bg-primary-600 hover:shadow-lg hover:shadow-primary-500/30"
+            >
+              About Me
+            </a>
+            <a
+              href="#works"
+              className="rounded-full border border-border-accent bg-primary-500/10 px-6 py-2.5 text-sm font-medium text-primary-400 no-underline transition-all hover:bg-primary-500/20 hover:border-primary-400"
+            >
+              View Works
+            </a>
+          </div>
           <a
             href="#about"
-            className="rounded-full bg-primary-500 px-6 py-2.5 text-sm font-medium text-white no-underline transition-all hover:bg-primary-600 hover:shadow-lg hover:shadow-primary-500/25"
+            aria-label="Scroll down"
+            className="scroll-indicator mt-16 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle text-primary-400 no-underline transition-colors hover:border-border-accent hover:text-primary-400"
           >
-            About Me
-          </a>
-          <a
-            href="#works"
-            className="rounded-full border border-border-accent bg-primary-500/10 px-6 py-2.5 text-sm font-medium text-primary-400 no-underline transition-all hover:bg-primary-500/20"
-          >
-            View Works
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
           </a>
         </div>
       </section>
 
       {/* About & Biography */}
-      <About />
-      <Biography />
+      <ScrollReveal>
+        <About />
+      </ScrollReveal>
+      <ScrollReveal delay={80}>
+        <Biography />
+      </ScrollReveal>
 
       {/* Career Section */}
-      <section className="py-16">
-        <SectionHeader id="career">Career</SectionHeader>
-        <div className="mx-auto max-w-2xl">
-          <CareerList items={careerData} />
-        </div>
-      </section>
+      <ScrollReveal>
+        <section className="py-16">
+          <SectionHeader id="career">Career</SectionHeader>
+          <div className="mx-auto max-w-2xl">
+            <CareerList items={careerData} />
+          </div>
+        </section>
+      </ScrollReveal>
 
       {/* Works Section */}
-      <section className="py-16">
-        <SectionHeader id="works">Works</SectionHeader>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {data.map(({ title, content, language, link }) => (
-            <Works key={title} title={title} content={content} language={language} link={link} />
-          ))}
-        </div>
-      </section>
+      <ScrollReveal>
+        <section className="py-16">
+          <SectionHeader id="works">Works</SectionHeader>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {data.map(({ title, content, language, link }) => (
+              <Works key={title} title={title} content={content} language={language} link={link} />
+            ))}
+          </div>
+        </section>
+      </ScrollReveal>
     </div>
   );
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -11,7 +11,7 @@ const About = () => {
   ];
 
   return (
-    <section id="about" className="w-full scroll-mt-20 py-20">
+    <section id="about" className="w-full scroll-mt-20 pb-16 pt-6">
       <div className="mx-auto flex max-w-2xl flex-col items-center gap-10 md:flex-row md:items-start md:gap-14">
         {/* Profile Image */}
         <div className="shrink-0">

--- a/src/components/Biography.tsx
+++ b/src/components/Biography.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Biography = () => {
   return (
-    <section className="w-full py-16">
+    <section id="biography" className="w-full scroll-mt-20 py-16">
       <div className="mx-auto max-w-2xl">
         <h2 className="gradient-text mb-8 text-center text-3xl font-bold">Biography</h2>
         <div className="glass-card space-y-5 rounded-2xl p-6 sm:p-8">

--- a/src/components/SectionArrow.tsx
+++ b/src/components/SectionArrow.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+type Props = {
+  href: string;
+  label?: string;
+};
+
+const SectionArrow = ({ href, label = 'Scroll down' }: Props) => (
+  <div className="mt-10 flex justify-center">
+    <a
+      href={href}
+      aria-label={label}
+      className="scroll-indicator inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle text-primary-400 no-underline transition-colors hover:border-border-accent"
+    >
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </a>
+  </div>
+);
+
+export default SectionArrow;

--- a/src/components/effects/AmbientBackground.tsx
+++ b/src/components/effects/AmbientBackground.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const AmbientBackground = () => (
+  <div aria-hidden className="aurora">
+    <span />
+    <span />
+    <span />
+  </div>
+);
+
+export default AmbientBackground;

--- a/src/components/effects/CursorSpotlight.tsx
+++ b/src/components/effects/CursorSpotlight.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const CursorSpotlight = () => {
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    if (window.matchMedia('(hover: none)').matches) return;
+
+    let raf = 0;
+    let lastX = 0;
+    let lastY = 0;
+
+    const apply = () => {
+      raf = 0;
+      const cards = document.querySelectorAll<HTMLElement>('.glass-card');
+      const vh = window.innerHeight;
+      cards.forEach((card) => {
+        const rect = card.getBoundingClientRect();
+        if (rect.bottom < -200 || rect.top > vh + 200) return;
+        card.style.setProperty('--mouse-x', `${lastX - rect.left}px`);
+        card.style.setProperty('--mouse-y', `${lastY - rect.top}px`);
+      });
+    };
+
+    const handleMove = (e: MouseEvent) => {
+      lastX = e.clientX;
+      lastY = e.clientY;
+      if (!raf) raf = requestAnimationFrame(apply);
+    };
+
+    window.addEventListener('mousemove', handleMove, { passive: true });
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return null;
+};
+
+export default CursorSpotlight;

--- a/src/components/effects/ScrollReveal.tsx
+++ b/src/components/effects/ScrollReveal.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+
+type Props = {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+};
+
+const ScrollReveal = ({ children, delay = 0, className = '' }: Props) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      el.classList.add('is-visible');
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add('is-visible');
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -60px 0px' }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className={`reveal ${className}`} style={{ transitionDelay: `${delay}ms` }}>
+      {children}
+    </div>
+  );
+};
+
+export default ScrollReveal;

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -13,19 +13,19 @@ const Header = () => {
         <nav className="flex items-center gap-6">
           <a
             href="#about"
-            className="text-sm text-text-secondary no-underline transition-colors hover:text-text-primary"
+            className="nav-link text-sm text-text-secondary no-underline transition-colors hover:text-text-primary"
           >
             About
           </a>
           <a
             href="#career"
-            className="text-sm text-text-secondary no-underline transition-colors hover:text-text-primary"
+            className="nav-link text-sm text-text-secondary no-underline transition-colors hover:text-text-primary"
           >
             Career
           </a>
           <a
             href="#works"
-            className="text-sm text-text-secondary no-underline transition-colors hover:text-text-primary"
+            className="nav-link text-sm text-text-secondary no-underline transition-colors hover:text-text-primary"
           >
             Works
           </a>


### PR DESCRIPTION
- aurora風の動くblob背景 (AmbientBackground)
- マウス追従スポットライト (CursorSpotlight) を .glass-card に適用
- IntersectionObserverベースのスクロールフェードイン (ScrollReveal)
- Heroセクションにグロー・順次フェードイン・スクロール誘導アイコン
- パレットを青/シアン/ディープブルー基調に刷新
- ナビ下線アニメーション・CTAグロー・カードホバーの影付き演出
- prefers-reduced-motion で全アニメ無効化