### PR TITLE
feat(styles): centralize color tokens in src/styles/colors.ts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,21 +1,5 @@
 @import 'tailwindcss';
-
-@theme {
-  --font-sans: 'Inter', 'Noto Sans JP', system-ui, -apple-system, sans-serif;
-  --color-primary-400: #60a5fa;
-  --color-primary-500: #3b82f6;
-  --color-primary-600: #2563eb;
-  --color-accent-cyan: #38bdf8;
-  --color-accent-deep: #1e40af;
-  --color-surface: #05080f;
-  --color-surface-card: rgba(255, 255, 255, 0.035);
-  --color-surface-card-hover: rgba(96, 165, 250, 0.08);
-  --color-border-subtle: rgba(255, 255, 255, 0.07);
-  --color-border-accent: rgba(59, 130, 246, 0.35);
-  --color-text-primary: #e6edf7;
-  --color-text-secondary: #94a3b8;
-  --color-text-muted: #64748b;
-}
+@config "../../tailwind.config.ts";
 
 html {
   scroll-behavior: smooth;
@@ -29,7 +13,12 @@ body {
 
 /* Gradient text — blue→cyan→deep-blue shimmer */
 .gradient-text {
-  background: linear-gradient(135deg, #7dd3fc 0%, #38bdf8 45%, #3b82f6 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-300) 0%,
+    var(--color-accent-cyan) 45%,
+    var(--color-primary-500) 100%
+  );
   background-size: 200% 200%;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -69,8 +58,8 @@ body {
   border-radius: inherit;
   background: radial-gradient(
     480px circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-    rgba(96, 165, 250, 0.22),
-    rgba(56, 189, 248, 0.1) 25%,
+    var(--color-glow-primary-soft),
+    var(--color-glow-cyan-soft) 25%,
     transparent 55%
   );
   opacity: 0;
@@ -92,7 +81,7 @@ body {
   background: var(--color-surface-card-hover);
   border-color: var(--color-border-accent);
   transform: translateY(-3px);
-  box-shadow: 0 14px 40px -10px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 14px 40px -10px var(--color-glow-btn-shadow);
 }
 
 /* Section fade-in (legacy utility) */
@@ -136,7 +125,12 @@ body {
   position: absolute;
   inset: -2px;
   border-radius: inherit;
-  background: linear-gradient(135deg, #60a5fa, #38bdf8, #1e40af);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-400),
+    var(--color-accent-cyan),
+    var(--color-accent-deep)
+  );
   opacity: 0.55;
   transition: opacity 0.3s ease;
   z-index: -1;
@@ -174,8 +168,8 @@ body {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #60a5fa, #38bdf8);
-  box-shadow: 0 0 12px rgba(96, 165, 250, 0.7);
+  background: linear-gradient(135deg, var(--color-primary-400), var(--color-accent-cyan));
+  box-shadow: 0 0 12px var(--color-glow-primary-strong);
   z-index: 1;
 }
 
@@ -186,7 +180,7 @@ body {
   top: 1.6rem;
   width: 2px;
   height: calc(100% - 0.6rem);
-  background: linear-gradient(to bottom, rgba(96, 165, 250, 0.45), transparent);
+  background: linear-gradient(to bottom, var(--color-glow-primary-medium), transparent);
 }
 
 .timeline-item:last-child::after {
@@ -195,11 +189,7 @@ body {
 
 /* Subtle grid pattern */
 .bg-grid-pattern {
-  background-image: radial-gradient(
-    circle at 1px 1px,
-    rgba(125, 211, 252, 0.05) 1px,
-    transparent 0
-  );
+  background-image: radial-gradient(circle at 1px 1px, var(--color-glow-grid-dot) 1px, transparent 0);
   background-size: 40px 40px;
 }
 
@@ -210,9 +200,9 @@ body {
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 500;
-  background: rgba(59, 130, 246, 0.14);
-  color: #93c5fd;
-  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: var(--color-glow-badge-bg);
+  color: var(--color-primary-700);
+  border: 1px solid var(--color-glow-badge-border);
   transition:
     background 0.3s ease,
     border-color 0.3s ease,
@@ -220,9 +210,9 @@ body {
 }
 
 .tech-badge:hover {
-  background: rgba(59, 130, 246, 0.24);
-  border-color: rgba(96, 165, 250, 0.5);
-  color: #bfdbfe;
+  background: var(--color-glow-badge-bg-hover);
+  border-color: var(--color-border-accent-strong);
+  color: var(--color-primary-800);
 }
 
 /* Aurora ambient background — blue/cyan blobs over near-black */
@@ -245,7 +235,7 @@ body {
 .aurora span:nth-child(1) {
   width: 520px;
   height: 520px;
-  background: radial-gradient(circle, #3b82f6 0%, transparent 70%);
+  background: radial-gradient(circle, var(--color-primary-500) 0%, transparent 70%);
   top: -140px;
   left: -120px;
   animation: floatA 22s ease-in-out infinite;
@@ -254,7 +244,7 @@ body {
 .aurora span:nth-child(2) {
   width: 620px;
   height: 620px;
-  background: radial-gradient(circle, #38bdf8 0%, transparent 70%);
+  background: radial-gradient(circle, var(--color-accent-cyan) 0%, transparent 70%);
   top: 22%;
   right: -180px;
   animation: floatB 28s ease-in-out infinite;
@@ -264,7 +254,7 @@ body {
 .aurora span:nth-child(3) {
   width: 440px;
   height: 440px;
-  background: radial-gradient(circle, #1e40af 0%, transparent 70%);
+  background: radial-gradient(circle, var(--color-accent-deep) 0%, transparent 70%);
   bottom: -120px;
   left: 28%;
   animation: floatC 26s ease-in-out infinite;
@@ -318,7 +308,7 @@ body {
   max-width: 90vw;
   max-height: 90vw;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(59, 130, 246, 0.38) 0%, transparent 65%);
+  background: radial-gradient(circle, var(--color-glow-hero-glow) 0%, transparent 65%);
   filter: blur(60px);
   pointer-events: none;
   animation: pulseGlow 7s ease-in-out infinite;
@@ -353,7 +343,7 @@ body {
   bottom: -4px;
   height: 2px;
   width: 100%;
-  background: linear-gradient(90deg, #60a5fa, #38bdf8);
+  background: linear-gradient(90deg, var(--color-primary-400), var(--color-accent-cyan));
   transform: scaleX(0);
   transform-origin: right center;
   transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
@@ -398,7 +388,12 @@ body {
   position: absolute;
   inset: -2px;
   border-radius: inherit;
-  background: linear-gradient(135deg, #60a5fa, #38bdf8, #2563eb);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-400),
+    var(--color-accent-cyan),
+    var(--color-primary-600)
+  );
   opacity: 0;
   filter: blur(14px);
   transition: opacity 0.3s ease;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,12 +3,14 @@ import Header from '../components/layouts/Header';
 import Footer from '../components/layouts/Footer';
 import AmbientBackground from '../components/effects/AmbientBackground';
 import CursorSpotlight from '../components/effects/CursorSpotlight';
+import { colorRootCss } from '../styles/colorVariables';
 import './globals.css';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
       <head>
+        <style dangerouslySetInnerHTML={{ __html: colorRootCss }} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         {/* eslint-disable-next-line @next/next/no-page-custom-font */}

--- a/src/styles/colorVariables.ts
+++ b/src/styles/colorVariables.ts
@@ -1,0 +1,27 @@
+import { colors } from './colors';
+
+/**
+ * Build a CSS `:root { --color-…: …; }` block from the `colors` tokens so
+ * `globals.css` can reference `var(--color-…)`. Keeps `colors.ts` as the
+ * single source of truth.
+ */
+const toCssVarName = (path: string[]) => {
+  const segments = path.map((segment) => (segment === 'DEFAULT' ? '' : segment)).filter(Boolean);
+  return `--color-${segments.join('-')}`;
+};
+
+const flatten = (value: unknown, path: string[] = []): Array<{ name: string; value: string }> => {
+  if (typeof value === 'string') {
+    return [{ name: toCssVarName(path), value }];
+  }
+  if (value && typeof value === 'object') {
+    return Object.entries(value).flatMap(([key, child]) => flatten(child, [...path, key]));
+  }
+  return [];
+};
+
+export const colorCssVariables = flatten(colors)
+  .map(({ name, value }) => `  ${name}: ${value};`)
+  .join('\n');
+
+export const colorRootCss = `:root {\n${colorCssVariables}\n}`;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,0 +1,55 @@
+/**
+ * Centralized color tokens for the portfolio site.
+ * This file is the single source of truth for all colors.
+ *
+ * - `tailwind.config.ts` imports `colors` to expose Tailwind utility classes
+ *   (e.g. `bg-primary-500`, `text-text-secondary`).
+ * - `globals.css` references the corresponding `var(--color-…)` CSS variables
+ *   that Tailwind generates from this object.
+ *
+ * Do NOT introduce raw hex / rgb / rgba literals anywhere else in the codebase.
+ */
+
+export const colors = {
+  primary: {
+    300: '#7dd3fc',
+    400: '#60a5fa',
+    500: '#3b82f6',
+    600: '#2563eb',
+    700: '#93c5fd',
+    800: '#bfdbfe',
+  },
+  accent: {
+    cyan: '#38bdf8',
+    deep: '#1e40af',
+  },
+  surface: {
+    DEFAULT: '#05080f',
+    card: 'rgba(255, 255, 255, 0.035)',
+    'card-hover': 'rgba(96, 165, 250, 0.08)',
+  },
+  border: {
+    subtle: 'rgba(255, 255, 255, 0.07)',
+    accent: 'rgba(59, 130, 246, 0.35)',
+    'accent-strong': 'rgba(96, 165, 250, 0.5)',
+  },
+  text: {
+    primary: '#e6edf7',
+    secondary: '#94a3b8',
+    muted: '#64748b',
+  },
+  glow: {
+    'primary-soft': 'rgba(96, 165, 250, 0.22)',
+    'primary-medium': 'rgba(96, 165, 250, 0.45)',
+    'primary-strong': 'rgba(96, 165, 250, 0.7)',
+    'cyan-soft': 'rgba(56, 189, 248, 0.1)',
+    'badge-bg': 'rgba(59, 130, 246, 0.14)',
+    'badge-bg-hover': 'rgba(59, 130, 246, 0.24)',
+    'badge-border': 'rgba(59, 130, 246, 0.25)',
+    'hero-glow': 'rgba(59, 130, 246, 0.38)',
+    'btn-shadow': 'rgba(59, 130, 246, 0.3)',
+    'grid-dot': 'rgba(125, 211, 252, 0.05)',
+  },
+} as const;
+
+export type Colors = typeof colors;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import { colors } from './src/styles/colors';
 
 const config: Config = {
   content: [
@@ -6,5 +7,13 @@ const config: Config = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  theme: {
+    extend: {
+      colors,
+      fontFamily: {
+        sans: ['Inter', 'Noto Sans JP', 'system-ui', '-apple-system', 'sans-serif'],
+      },
+    },
+  },
 };
 export default config;


### PR DESCRIPTION
- Add colors.ts as the single source of truth for all color values (primary scale, accent, surface, border, text, ambient glows)
- Wire tailwind.config.ts via @config directive so utility classes (e.g. bg-primary-500, text-text-secondary) read from the same tokens
- Inject :root CSS variables in layout.tsx from colors.ts so the hand-written rules in globals.css can reference var(--color-...) consistently, with no duplicated literals
- Remove all hardcoded hex / rgba values from globals.css; replace with the corresponding CSS variables

Closes #34

https://claude.ai/code/session_01PW4PKNZGsZMy9nYN9jyqNF